### PR TITLE
Added getting notes function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rgoogleslides
 Type: Package
 Title: R Interface to Google Slides
-Version: 0.3.2.9000
+Version: 0.3.1.9000
 Author: Hairizuan Bin Noorazman
 Maintainer: Hairizuan Noorazman <hairizuanbinnoorazman@gmail.com>
 Description: Previously, when one is working with in the Google Ecosystem (Using Google Drive etc), there is hardly any good workflow of getting the values calculated from R and getting that into Google Slides. The normal and easy way out would be to just copy your work over but when you have a number of analysis to present with a lot of changes between each environment, it just becomes quite cumbersome.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rgoogleslides
 Type: Package
 Title: R Interface to Google Slides
-Version: 0.3.1
+Version: 0.3.1.9000
 Author: Hairizuan Bin Noorazman
 Maintainer: Hairizuan Noorazman <hairizuanbinnoorazman@gmail.com>
 Description: Previously, when one is working with in the Google Ecosystem (Using Google Drive etc), there is hardly any good workflow of getting the values calculated from R and getting that into Google Slides. The normal and easy way out would be to just copy your work over but when you have a number of analysis to present with a lot of changes between each environment, it just becomes quite cumbersome.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rgoogleslides
 Type: Package
 Title: R Interface to Google Slides
-Version: 0.3.1.9000
+Version: 0.3.2.9000
 Author: Hairizuan Bin Noorazman
 Maintainer: Hairizuan Noorazman <hairizuanbinnoorazman@gmail.com>
 Description: Previously, when one is working with in the Google Ecosystem (Using Google Drive etc), there is hardly any good workflow of getting the values calculated from R and getting that into Google Slides. The normal and easy way out would be to just copy your work over but when you have a number of analysis to present with a lot of changes between each environment, it just becomes quite cumbersome.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,4 +16,4 @@ Suggests:
     knitr,
     rmarkdown,
     testthat
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1

--- a/R/auth.R
+++ b/R/auth.R
@@ -20,17 +20,20 @@ get_token <- function() {
 #' @param client_secret OAuth client secret. This is obtained from Google API Credentials
 #' @param token an output from \code{\link{oauth2.0_token}} to set as the
 #' authentication token.
+#' @param ... additional arguments to send to \code{\link{oauth2.0_token}}
 #' @export
 authorize <- function(
   client_id = getOption("slides.client.id"),
   client_secret = getOption("slides.client.secret"),
-  token = NULL){
+  token = NULL,
+  ...){
   if (is.null(token)) {
     app <- oauth_app(appname = "googleslides", key = client_id, secret = client_secret)
     endpoint <- oauth_endpoints("google")
     token <- oauth2.0_token(endpoint = endpoint, app = app,
                             scope = c("https://www.googleapis.com/auth/presentations",
-                                      "https://www.googleapis.com/auth/drive.readonly"))
+                                      "https://www.googleapis.com/auth/drive.readonly"),
+                            ...)
   }
   set_token(token)
   return(invisible(token))

--- a/R/slides.R
+++ b/R/slides.R
@@ -160,6 +160,9 @@ slide_page_container <- R6Class('SlidePage',
           }
         }
       }
+      if (nrow(list_text_boxes) == 0) {
+        list_text_boxes = data.frame(x=character(0), y = character(0))
+      }
       names(list_text_boxes) <- c('object_id', 'text_content')
       return(list_text_boxes)
     },
@@ -187,6 +190,9 @@ slide_page_container <- R6Class('SlidePage',
                     stringsAsFactors = FALSE)
           }
         }
+      }
+      if (nrow(list_text_boxes) == 0) {
+        list_text_boxes = data.frame(x=character(0), y = character(0))
       }
       names(list_text_boxes) <- c('object_id', 'text_content')
       return(list_text_boxes)

--- a/R/slides.R
+++ b/R/slides.R
@@ -30,13 +30,11 @@ create_slides <- function(title = NULL, full_response = FALSE){
 
 #' Get Google Slides Properties
 #' @param id ID of the presentation slide
-#' @param as desired type of output: raw, text or parsed. Passed to
-#' \code{\link[httr]{content}}
 #' @importFrom httr config accept_json content
 #' @importFrom jsonlite fromJSON
 #' @importFrom assertthat assert_that is.string
 #' @export
-get_slides_properties <- function(id, as = NULL){
+get_slides_properties <- function(id){
   # Check validity of inputs
   assert_that(is.string(id))
 
@@ -46,14 +44,14 @@ get_slides_properties <- function(id, as = NULL){
   token <- get_token()
   config <- httr::config(token=token)
   # Get slide properties
-  result <- httr::GET(url, config = config, httr::accept_json())
+  result <- httr::GET(url, config = config, accept_json())
   if(httr::status_code(result) != 200){
     stop("ID provided does not point towards any slide")
   }
   # Process and return results
-  result_content <- httr::content(result, as = as)
-  # result_list <- fromJSON(result_content)
-  return(result_content)
+  result_content <- content(result, "text")
+  result_list <- fromJSON(result_content)
+  return(result_list)
 }
 
 #' Get a single page of a Google Slides property

--- a/R/slides.R
+++ b/R/slides.R
@@ -30,11 +30,13 @@ create_slides <- function(title = NULL, full_response = FALSE){
 
 #' Get Google Slides Properties
 #' @param id ID of the presentation slide
+#' @param as desired type of output: raw, text or parsed. Passed to
+#' \code{\link[httr]{content}}
 #' @importFrom httr config accept_json content
 #' @importFrom jsonlite fromJSON
 #' @importFrom assertthat assert_that is.string
 #' @export
-get_slides_properties <- function(id){
+get_slides_properties <- function(id, as = NULL){
   # Check validity of inputs
   assert_that(is.string(id))
 
@@ -44,14 +46,14 @@ get_slides_properties <- function(id){
   token <- get_token()
   config <- httr::config(token=token)
   # Get slide properties
-  result <- httr::GET(url, config = config, accept_json())
+  result <- httr::GET(url, config = config, httr::accept_json())
   if(httr::status_code(result) != 200){
     stop("ID provided does not point towards any slide")
   }
   # Process and return results
-  result_content <- content(result, "text")
-  result_list <- fromJSON(result_content)
-  return(result_list)
+  result_content <- httr::content(result, as = as)
+  # result_list <- fromJSON(result_content)
+  return(result_content)
 }
 
 #' Get a single page of a Google Slides property

--- a/R/slides.R
+++ b/R/slides.R
@@ -162,6 +162,34 @@ slide_page_container <- R6Class('SlidePage',
       }
       names(list_text_boxes) <- c('object_id', 'text_content')
       return(list_text_boxes)
+    },
+    # Retrieve a list of notes from the raw response
+    get_notes = function() {
+      list_text_boxes <- data.frame(stringsAsFactors = FALSE)
+      for (item in self$raw_response$slideProperties$notesPage$pageElements) {
+        if (!is.null(item$shape$shapeType)) {
+          if (item$shape$shapeType == "TEXT_BOX") {
+            # Retrieve text content
+            text_content <- ""
+            if (!is.null(item$shape$text$textElements)) {
+              for (text_element in item$shape$text$textElements) {
+                text_content <- paste0(text_content, text_element$textRun$content)
+              }
+            }
+
+            # Retrieve object id
+            object_id = item$objectId
+
+            # Concatenate results
+            list_text_boxes <-
+              rbind(list_text_boxes,
+                    c(object_id, text_content),
+                    stringsAsFactors = FALSE)
+          }
+        }
+      }
+      names(list_text_boxes) <- c('object_id', 'text_content')
+      return(list_text_boxes)
     }
   )
 )

--- a/R/slides.R
+++ b/R/slides.R
@@ -15,7 +15,8 @@ create_slides <- function(title = NULL, full_response = FALSE){
   # Modify slides
   result <- httr::POST(url, config = config, accept_json(), body = body_params, encode = "json")
   if(httr::status_code(result) != 200){
-    stop("ID provided does not point towards any slide")
+    message("Cannot create slides")
+    httr::stop_for_status(result)
   }
   # Process and return results
   result_content <- content(result, "text")
@@ -46,7 +47,8 @@ get_slides_properties <- function(id){
   # Get slide properties
   result <- httr::GET(url, config = config, accept_json())
   if(httr::status_code(result) != 200){
-    stop("ID provided does not point towards any slide")
+    message("ID provided does not point towards any slide")
+    httr::stop_for_status(result)
   }
   # Process and return results
   result_content <- content(result, "text")

--- a/man/authorize.Rd
+++ b/man/authorize.Rd
@@ -5,7 +5,7 @@
 \title{Authorize R package to access Google Slides API}
 \usage{
 authorize(client_id = getOption("slides.client.id"),
-  client_secret = getOption("slides.client.secret"), token = NULL)
+  client_secret = getOption("slides.client.secret"), token = NULL, ...)
 }
 \arguments{
 \item{client_id}{OAuth client ID. This is obtained from Google API Credentials}
@@ -14,6 +14,8 @@ authorize(client_id = getOption("slides.client.id"),
 
 \item{token}{an output from \code{\link{oauth2.0_token}} to set as the
 authentication token.}
+
+\item{...}{additional arguments to send to \code{\link{oauth2.0_token}}}
 }
 \description{
 This is a function to authorize the R package to access the Googleslides API. If no

--- a/man/get_slides_properties.Rd
+++ b/man/get_slides_properties.Rd
@@ -4,13 +4,10 @@
 \alias{get_slides_properties}
 \title{Get Google Slides Properties}
 \usage{
-get_slides_properties(id, as = NULL)
+get_slides_properties(id)
 }
 \arguments{
 \item{id}{ID of the presentation slide}
-
-\item{as}{desired type of output: raw, text or parsed. Passed to
-\code{\link[httr]{content}}}
 }
 \description{
 Get Google Slides Properties

--- a/man/get_slides_properties.Rd
+++ b/man/get_slides_properties.Rd
@@ -4,10 +4,13 @@
 \alias{get_slides_properties}
 \title{Get Google Slides Properties}
 \usage{
-get_slides_properties(id)
+get_slides_properties(id, as = NULL)
 }
 \arguments{
 \item{id}{ID of the presentation slide}
+
+\item{as}{desired type of output: raw, text or parsed. Passed to
+\code{\link[httr]{content}}}
 }
 \description{
 Get Google Slides Properties


### PR DESCRIPTION
Allows users to get the notes from a slide deck.  Also, messages occur now in case there are redirects.

The `httr` stops allows the true message from Google to be shown (like Not authorized), rather than just the slides don't exist.